### PR TITLE
Add swagger docs to project. 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,16 @@
 				</exclusion>
 			</exclusions>
 		</dependency>
+		<dependency>
+			<groupId>io.springfox</groupId>
+			<artifactId>springfox-swagger2</artifactId>
+			<version>2.9.2</version>
+		</dependency>
+		<dependency>
+			<groupId>io.springfox</groupId>
+			<artifactId>springfox-swagger-ui</artifactId>
+			<version>2.9.2</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/bincoding/nonprofit/NonprofitApplication.java
+++ b/src/main/java/com/bincoding/nonprofit/NonprofitApplication.java
@@ -2,8 +2,10 @@ package com.bincoding.nonprofit;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import springfox.documentation.swagger2.annotations.EnableSwagger2;
 
 @SpringBootApplication
+@EnableSwagger2
 public class NonprofitApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/bincoding/nonprofit/controller/DefaultController.java
+++ b/src/main/java/com/bincoding/nonprofit/controller/DefaultController.java
@@ -6,6 +6,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@RequestMapping("/api")
 public class DefaultController {
 
     @GetMapping(value = {"/", "/index"})


### PR DESCRIPTION
#What
Added docs for api documentation. We can maintain a consistent reference for all users to be able to interact with api. 

#How
You can access this current at `/v2/api-docs` or the ui at `/swagger-ui.html`. These resource names might be changed at some point. 